### PR TITLE
Remove galactic from matrix and revert to default uncrustify

### DIFF
--- a/.github/workflows/reusable_build.yaml
+++ b/.github/workflows/reusable_build.yaml
@@ -15,9 +15,7 @@ on:
         required: false
         type: string
         default: |
-          [{"ros_distribution": "galactic",
-            "ubuntu_distribution": "focal"},
-          {"ros_distribution": "humble",
+          [{"ros_distribution": "humble",
             "ubuntu_distribution": "jammy"},
           {"ros_distribution": "rolling",
             "ubuntu_distribution": "jammy"}]
@@ -42,21 +40,13 @@ jobs:
     steps:
       - name: install_clang_and_tools
         run: sudo apt update && sudo apt install -y clang clang-tools lld wget python3-pip python3-colcon-coveragepy-result python3-colcon-lcov-result lcov
-      # TODO: fix for cryptography>2.8 failing in galactic https://github.com/open-rmf/rmf/pull/202#pullrequestreview-1100045417
-      - name: fix cryptography==2.8 # https://github.com/open-rmf/rmf/pull/202#pullrequestreview-1100045417
-        run: pip3 install cryptography==2.8
-        if: ${{ matrix.ros_distribution == 'galactic' || matrix.ros_distribution == 'foxy' }}
-      # TODO: remove this when uncrustify 0.72 is fixed https://github.com/uncrustify/uncrustify/issues/3191
-      - name: hack for uncrustify 0.72 problems
-        run: wget http://mirrors.kernel.org/ubuntu/pool/universe/u/uncrustify/uncrustify_0.69.0+dfsg1-1build1_amd64.deb && dpkg -i uncrustify_0.69.0+dfsg1-1build1_amd64.deb && apt install -f -y
-        if: ${{ matrix.ubuntu_distribution == 'jammy'}}
       # TODO: Remove this step when the incompatibility between libunwind14 and libundind dissapears https://github.com/open-rmf/rmf_traffic_editor/issues/439
       - name: Horrible hack for libceres
         run: |
-          apt-get remove -y --purge libc++-dev || true 
+          apt-get remove -y --purge libc++-dev || true
           apt-get remove -y --purge libc++abi-dev || true
-          apt-get remove -y --purge libunwind-14-dev || true 
-          apt-get remove -y --purge libunwind-14-dev || true 
+          apt-get remove -y --purge libunwind-14-dev || true
+          apt-get remove -y --purge libunwind-14-dev || true
           apt-get remove -y --purge libunwind-dev || true
           apt -y autoremove
         if: ${{ matrix.ubuntu_distribution == 'jammy'}}
@@ -78,7 +68,7 @@ jobs:
                 echo 'colcon_defaults={"build":{"mixin":["tsan"],"cmake-args":["-DCMAKE_BUILD_TYPE=Debug"]}}' >> $GITHUB_OUTPUT
                 ;;
             *)
-                echo 'colcon_defaults={"build": {"mixin": ["coverage-gcc", "lld" ]}}' >> $GITHUB_OUTPUT 
+                echo 'colcon_defaults={"build": {"mixin": ["coverage-gcc", "lld" ]}}' >> $GITHUB_OUTPUT
                 ;;
           esac
       - name: build_and_test


### PR DESCRIPTION
`galactic` is EOL so we shouldn't include it in the default matrix.  Also it appears we were using a non-default version of uncrustify. This was concealing errors that will occur in the buildfarm which uses the default version of uncrustify.
See https://build.ros2.org/job/Rbin_uJ64__rmf_fleet_adapter__ubuntu_jammy_amd64__binary/196/console