### PR TITLE
Update action-ros-ci to v0.3

### DIFF
--- a/.github/workflows/reusable_asan.yaml
+++ b/.github/workflows/reusable_asan.yaml
@@ -56,7 +56,7 @@ jobs:
           touch ${{ github.workspace }}/blacklist.txt
           echo "fun:*Eigen*" >  ${{ github.workspace }}/blacklist.txt
       - name: asan_build_and_test
-        uses: ros-tooling/action-ros-ci@v0.2
+        uses: ros-tooling/action-ros-ci@v0.3
         env:
           LANG: en_US.UTF-8
           CC: clang -fsanitize-blacklist=${{ github.workspace }}/blacklist.txt

--- a/.github/workflows/reusable_build.yaml
+++ b/.github/workflows/reusable_build.yaml
@@ -72,7 +72,7 @@ jobs:
                 ;;
           esac
       - name: build_and_test
-        uses: ros-tooling/action-ros-ci@v0.2
+        uses: ros-tooling/action-ros-ci@v0.3
         env:
           LANG: en_US.UTF-8
           CC: clang -fsanitize-blacklist=${{ github.workspace }}/blacklist.txt


### PR DESCRIPTION
Iron is only supported starting from [0.3.1 onwards](https://github.com/ros-tooling/action-ros-ci/releases/tag/0.3.1), so we should bump the `action-ros-ci` version