### PR TITLE
Add optional argument to override repos file

### DIFF
--- a/.github/workflows/reusable_build.yaml
+++ b/.github/workflows/reusable_build.yaml
@@ -27,7 +27,7 @@ on:
         description: branch to use for rmf.repos file, defaults to the branch named after the ros distribution in the matrix
         required: false
         type: string
-        default: ''
+        default: ""
 defaults:
   run:
     shell: bash
@@ -75,14 +75,13 @@ jobs:
         with:
           path: ~/.cache/ccache
           key: ccache
-      - name: set repos file if branch branch override is present
-        if: ${{ inputs.repos-branch-override }} != ''
+      - name: set repos file
         run: |
-          echo "REPOS_URL=https://raw.githubusercontent.com/open-rmf/rmf/${{ inputs.repos-branch-override }}/rmf.repos" >> $GITHUB_ENV
-      - name: set repos file if branch branch override is not present
-        if: ${{ inputs.repos-branch-override }} == ''
-        run: |
-          echo "REPOS_URL=https://raw.githubusercontent.com/open-rmf/rmf/${{ matrix.ros-distribution }}/rmf.repos" >> $GITHUB_ENV
+          if [ -z ${{ inputs.repos-branch-override }} ]; then
+            echo "REPOS_URL=https://raw.githubusercontent.com/open-rmf/rmf/${{ matrix.ros_distribution }}/rmf.repos" >> $GITHUB_ENV
+          else
+            echo "REPOS_URL=https://raw.githubusercontent.com/open-rmf/rmf/${{ inputs.repos-branch-override }}/rmf.repos" >> $GITHUB_ENV
+          fi
       - name: build_and_test
         uses: ros-tooling/action-ros-ci@v0.3
         env:

--- a/.github/workflows/reusable_build.yaml
+++ b/.github/workflows/reusable_build.yaml
@@ -23,6 +23,11 @@ on:
            "ubuntu_distribution": "noble"},
           {"ros_distribution": "rolling",
             "ubuntu_distribution": "noble"}]
+      repos-branch-override:
+        description: branch to use for rmf.repos file, defaults to the branch named after the ros distribution in the matrix
+        required: false
+        type: string
+        default: ''
 defaults:
   run:
     shell: bash
@@ -70,6 +75,14 @@ jobs:
         with:
           path: ~/.cache/ccache
           key: ccache
+      - name: set repos file if branch branch override is present
+        if: ${{ inputs.repos-branch-override }} != ''
+        run: |
+          echo "REPOS_URL=https://raw.githubusercontent.com/open-rmf/rmf/${{ inputs.repos-branch-override }}/rmf.repos" >> $GITHUB_ENV
+      - name: set repos file if branch branch override is not present
+        if: ${{ inputs.repos-branch-override }} == ''
+        run: |
+          echo "REPOS_URL=https://raw.githubusercontent.com/open-rmf/rmf/${{ matrix.ros-distribution }}/rmf.repos" >> $GITHUB_ENV
       - name: build_and_test
         uses: ros-tooling/action-ros-ci@v0.3
         env:
@@ -85,8 +98,7 @@ jobs:
           target-ros2-distro: ${{ matrix.ros_distribution }}
           # build all packages listed in the meta package
           package-name: ${{ inputs.packages }}
-          vcs-repo-file-url: |
-            https://raw.githubusercontent.com/open-rmf/rmf/${{ matrix.ros_distribution }}/rmf.repos
+          vcs-repo-file-url: ${{ env.REPOS_URL }}
           colcon-defaults: ${{ steps.set_mixins.outputs.colcon_defaults }}
           colcon-mixin-repository: https://raw.githubusercontent.com/colcon/colcon-mixin-repository/master/index.yaml
       - name: Upload colcon build logs


### PR DESCRIPTION
This PR adds a new argument to the reusable build action `repos-branch-override` that allows overriding the branch uses for the `rmf.repos` file. If the argument is not specified it will default to the ROS distribution in the matrix entry that is being tested.

This allows testing different combinations of ROS distribution / branches, an example is in https://github.com/open-rmf/rmf_ros2/pull/374