### PR TITLE
Bump github upload artifact

### DIFF
--- a/.github/workflows/reusable_build.yaml
+++ b/.github/workflows/reusable_build.yaml
@@ -124,7 +124,7 @@ jobs:
           name: colcon-tsan-logs_${{ matrix.ubuntu_distribution }}_${{ matrix.ros_distribution }}
           path: ${{ steps.build_and_test.outputs.ros-workspace-directory-name }}/log
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@v4
         with:
           files: ros_ws/lcov/total_coverage.info
           flags: tests

--- a/.github/workflows/reusable_build.yaml
+++ b/.github/workflows/reusable_build.yaml
@@ -56,7 +56,7 @@ jobs:
       - name: Setup ROS
         uses: ros-tooling/setup-ros@v0.7
       - name: install_tools
-        run: sudo apt update && sudo apt install -y ccache clang clang-tools lld wget python3-pip python3-colcon-coveragepy-result python3-colcon-lcov-result lcov ros-${{ matrix.ros_distribution }}-rmw-cyclonedds-cpp
+        run: sudo apt update && sudo apt upgrade -y && sudo apt install -y ccache clang clang-tools lld wget python3-pip python3-colcon-coveragepy-result python3-colcon-lcov-result lcov ros-${{ matrix.ros_distribution }}-rmw-cyclonedds-cpp
       - name: set mixins
         id: set_mixins
         run: |

--- a/.github/workflows/reusable_build.yaml
+++ b/.github/workflows/reusable_build.yaml
@@ -103,7 +103,7 @@ jobs:
       - name: Upload colcon build logs
         uses: actions/upload-artifact@v4
         with:
-          name: colcon-build-logs
+          name: colcon-build-logs_${{ matrix.ubuntu_distribution }}_${{ matrix.ros_distribution }}
           path: ${{ steps.build_and_test.outputs.ros-workspace-directory-name }}/log
       - name: Upload colcon failed test results
         uses: actions/upload-artifact@v4
@@ -115,13 +115,13 @@ jobs:
         if:  ${{ inputs.mixin }} == "asan"
         uses: actions/upload-artifact@v4
         with:
-          name: colcon-asan-logs
+          name: colcon-asan-logs_${{ matrix.ubuntu_distribution }}_${{ matrix.ros_distribution }}
           path: ${{ steps.build_and_test.outputs.ros-workspace-directory-name }}/log
       - name: Upload tsan test logs
         if: ${{ inputs.mixin }} == "tsan"
         uses: actions/upload-artifact@v4
         with:
-          name: colcon-tsan-logs
+          name: colcon-tsan-logs_${{ matrix.ubuntu_distribution }}_${{ matrix.ros_distribution }}
           path: ${{ steps.build_and_test.outputs.ros-workspace-directory-name }}/log
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v3

--- a/.github/workflows/reusable_build.yaml
+++ b/.github/workflows/reusable_build.yaml
@@ -101,25 +101,25 @@ jobs:
           colcon-defaults: ${{ steps.set_mixins.outputs.colcon_defaults }}
           colcon-mixin-repository: https://raw.githubusercontent.com/colcon/colcon-mixin-repository/master/index.yaml
       - name: Upload colcon build logs
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: colcon-build-logs
           path: ${{ steps.build_and_test.outputs.ros-workspace-directory-name }}/log
       - name: Upload colcon failed test results
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         if: failure()
         with:
           name: test-results_${{ matrix.ubuntu_distribution }}_${{ matrix.ros_distribution }}
           path: ros_ws/build/*/test_results/*/*.xml
       - name: Upload asan test logs
         if:  ${{ inputs.mixin }} == "asan"
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: colcon-asan-logs
           path: ${{ steps.build_and_test.outputs.ros-workspace-directory-name }}/log
       - name: Upload tsan test logs
         if: ${{ inputs.mixin }} == "tsan"
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: colcon-tsan-logs
           path: ${{ steps.build_and_test.outputs.ros-workspace-directory-name }}/log

--- a/.github/workflows/reusable_build.yaml
+++ b/.github/workflows/reusable_build.yaml
@@ -71,7 +71,7 @@ jobs:
                 echo 'colcon_defaults={"build": {"mixin": ["ccache", "coverage-gcc", "lld"]}}' >> $GITHUB_OUTPUT
                 ;;
           esac
-      - uses: actions/cache@v3
+      - uses: actions/cache@v4
         with:
           path: ~/.cache/ccache
           key: ccache
@@ -124,7 +124,7 @@ jobs:
           name: colcon-tsan-logs
           path: ${{ steps.build_and_test.outputs.ros-workspace-directory-name }}/log
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v1
+        uses: codecov/codecov-action@v3
         with:
           files: ros_ws/lcov/total_coverage.info
           flags: tests


### PR DESCRIPTION
## Bug fix

### Fixed bug

The v2 version of `upload-artifacts` is deprecated and is causing failures in downstream repos with the following message:

```
This request has been automatically failed because it uses a deprecated version of `actions/upload-artifact: v2`. Learn more: https://github.blog/changelog/2024-02-13-deprecation-notice-v1-and-v2-of-the-artifact-actions/
```

### Fix applied

Bump it