### PR TITLE
Change Ubuntu distribution on Rolling to Resolute

### DIFF
--- a/.github/workflows/reusable_asan.yaml
+++ b/.github/workflows/reusable_asan.yaml
@@ -16,7 +16,7 @@ on:
           {"ros_distribution": "jazzy",
            "ubuntu_distribution": "noble"},
           {"ros_distribution": "rolling",
-            "ubuntu_distribution": "noble"}]
+            "ubuntu_distribution": "resolute"}]
 jobs:
   asan:
     name: asan

--- a/.github/workflows/reusable_build.yaml
+++ b/.github/workflows/reusable_build.yaml
@@ -20,7 +20,7 @@ on:
           {"ros_distribution": "jazzy",
            "ubuntu_distribution": "noble"},
           {"ros_distribution": "rolling",
-            "ubuntu_distribution": "noble"}]
+            "ubuntu_distribution": "resolute"}]
       repos-branch-override:
         description: branch to use for rmf.repos file, defaults to the branch named after the ros distribution in the matrix
         required: false


### PR DESCRIPTION
As per title, Rolling just transition to resolute so move our CI so we test on that.
In the process I found out that we didn't actually add kilted to our CI but since we are about 7 months away from EOL it's probably not worth it now.

Marking as draft since the first sync of Rolling on Resolute hasn't happened yet, we could [use ros2-testing](https://github.com/ros-tooling/setup-ros#Use-pre-release-ROS-2-binaries-for-testing) but I'm not sure it's worth it for a few weeks.