### PR TITLE
Use testing repos for Rolling

### DIFF
--- a/.github/workflows/reusable_build.yaml
+++ b/.github/workflows/reusable_build.yaml
@@ -100,6 +100,7 @@ jobs:
           vcs-repo-file-url: ${{ env.REPOS_URL }}
           colcon-defaults: ${{ steps.set_mixins.outputs.colcon_defaults }}
           colcon-mixin-repository: https://raw.githubusercontent.com/colcon/colcon-mixin-repository/master/index.yaml
+          use-ros2-testing: ${{ matrix.ros_distribution == 'rolling' }}
       - name: Upload colcon build logs
         uses: actions/upload-artifact@v4
         with:


### PR DESCRIPTION
As per title, and proposed in [#Open-RMF PMC (Restricted posting) > Bumping CI for lyrical @ 💬](https://openrobotics.zulipchat.com/#narrow/channel/526047-Open-RMF-PMC-.28Restricted-posting.29/topic/Bumping.20CI.20for.20lyrical/near/597714894).
Since Rolling still hasn't been bumped change the workflow to default using testing repos for Rolling.
This could make our CI slightly more flaky but should allow us to catch rolling breakages early.