### PR TITLE
Use a specific commit until setup-ros@0.7.19 is released

### DIFF
--- a/.github/workflows/reusable_build.yaml
+++ b/.github/workflows/reusable_build.yaml
@@ -73,10 +73,10 @@ jobs:
                 echo 'colcon_defaults={"build": {"mixin": ["ccache", "coverage-gcc", "lld"]}}' >> $GITHUB_OUTPUT
                 ;;
           esac
-      - uses: actions/cache@v4
-        with:
-          path: ~/.cache/ccache
-          key: ccache
+      # - uses: actions/cache@v4
+      #   with:
+      #     path: ~/.cache/ccache
+      #     key: ccache
       - name: set repos file
         run: |
           if [ -z ${{ inputs.repos-branch-override }} ]; then

--- a/.github/workflows/reusable_build.yaml
+++ b/.github/workflows/reusable_build.yaml
@@ -58,7 +58,7 @@ jobs:
           required-ros-distributions: ${{ matrix.ros_distribution }}
           use-ros2-testing: ${{ matrix.ros_distribution == 'rolling' }}
       - name: install_tools
-        run: sudo apt update && sudo apt upgrade -y && sudo apt install -y ccache clang clang-tools lld wget python3-pip python3-colcon-coveragepy-result python3-colcon-lcov-result lcov ros-${{ matrix.ros_distribution }}-rmw-cyclonedds-cpp build-essential libstdc++-dev
+        run: sudo apt update && sudo apt upgrade -y && sudo apt install -y ccache clang clang-tools lld wget python3-pip python3-colcon-coveragepy-result python3-colcon-lcov-result lcov ros-${{ matrix.ros_distribution }}-rmw-cyclonedds-cpp build-essential
       - name: set mixins
         id: set_mixins
         run: |

--- a/.github/workflows/reusable_build.yaml
+++ b/.github/workflows/reusable_build.yaml
@@ -58,7 +58,7 @@ jobs:
           required-ros-distributions: ${{ matrix.ros_distribution }}
           use-ros2-testing: ${{ matrix.ros_distribution == 'rolling' }}
       - name: install_tools
-        run: sudo apt update && sudo apt upgrade -y && sudo apt install -y ccache clang clang-tools lld wget python3-pip python3-colcon-coveragepy-result python3-colcon-lcov-result lcov ros-${{ matrix.ros_distribution }}-rmw-cyclonedds-cpp build-essential
+        run: sudo apt update && sudo apt upgrade -y && sudo apt install -y ccache clang clang-tools lld wget python3-pip python3-colcon-coveragepy-result python3-colcon-lcov-result lcov ros-${{ matrix.ros_distribution }}-rmw-cyclonedds-cpp build-essential libstdc++-dev
       - name: set mixins
         id: set_mixins
         run: |

--- a/.github/workflows/reusable_build.yaml
+++ b/.github/workflows/reusable_build.yaml
@@ -55,8 +55,7 @@ jobs:
       - name: Setup ROS
         uses: ros-tooling/setup-ros@a45da158f95f27fea0a57c88fa1da6275b0e4ed3
         with:
-          required-ros-distributions:
-           - ${{ matrix.ros_distribution }}
+          required-ros-distributions: ${{ matrix.ros_distribution }}
           use-ros2-testing: ${{ matrix.ros_distribution == 'rolling' }}
       - name: install_tools
         run: sudo apt update && sudo apt upgrade -y && sudo apt install -y ccache clang clang-tools lld wget python3-pip python3-colcon-coveragepy-result python3-colcon-lcov-result lcov ros-${{ matrix.ros_distribution }}-rmw-cyclonedds-cpp

--- a/.github/workflows/reusable_build.yaml
+++ b/.github/workflows/reusable_build.yaml
@@ -58,7 +58,7 @@ jobs:
           required-ros-distributions: ${{ matrix.ros_distribution }}
           use-ros2-testing: ${{ matrix.ros_distribution == 'rolling' }}
       - name: install_tools
-        run: sudo apt update && sudo apt upgrade -y && sudo apt install -y ccache clang clang-tools lld wget python3-pip python3-colcon-coveragepy-result python3-colcon-lcov-result lcov ros-${{ matrix.ros_distribution }}-rmw-cyclonedds-cpp
+        run: sudo apt update && sudo apt upgrade -y && sudo apt install -y ccache clang clang-tools lld wget python3-pip python3-colcon-coveragepy-result python3-colcon-lcov-result lcov ros-${{ matrix.ros_distribution }}-rmw-cyclonedds-cpp build-essential
       - name: set mixins
         id: set_mixins
         run: |

--- a/.github/workflows/reusable_build.yaml
+++ b/.github/workflows/reusable_build.yaml
@@ -56,7 +56,8 @@ jobs:
         #uses: ros-tooling/setup-ros@a45da158f95f27fea0a57c88fa1da6275b0e4ed3
         uses: mxgrey/setup-ros@explicit_libclang-rt-dev
         with:
-          required-ros-distributions: ${{ matrix.ros_distribution }}
+          required-ros-distribution: ${{ matrix.ros_distribution }}
+          # required-ros-distributions: ${{ matrix.ros_distribution }}
           use-ros2-testing: ${{ matrix.ros_distribution == 'rolling' }}
       - name: install_tools
         run: sudo apt update && sudo apt upgrade -y && sudo apt install -y ccache clang clang-tools lld wget python3-pip python3-colcon-coveragepy-result python3-colcon-lcov-result lcov ros-${{ matrix.ros_distribution }}-rmw-cyclonedds-cpp build-essential

--- a/.github/workflows/reusable_build.yaml
+++ b/.github/workflows/reusable_build.yaml
@@ -55,7 +55,8 @@ jobs:
       - name: Setup ROS
         uses: ros-tooling/setup-ros@a45da158f95f27fea0a57c88fa1da6275b0e4ed3
         with:
-          required-ros-distributions: [${{ matrix.ros_distribution }}]
+          required-ros-distributions:
+           - ${{ matrix.ros_distribution }}
           use-ros2-testing: ${{ matrix.ros_distribution == 'rolling' }}
       - name: install_tools
         run: sudo apt update && sudo apt upgrade -y && sudo apt install -y ccache clang clang-tools lld wget python3-pip python3-colcon-coveragepy-result python3-colcon-lcov-result lcov ros-${{ matrix.ros_distribution }}-rmw-cyclonedds-cpp

--- a/.github/workflows/reusable_build.yaml
+++ b/.github/workflows/reusable_build.yaml
@@ -53,7 +53,8 @@ jobs:
             echo "fun:*Eigen*" >  ${{ github.workspace }}/blacklist.txt
           fi
       - name: Setup ROS
-        uses: ros-tooling/setup-ros@a45da158f95f27fea0a57c88fa1da6275b0e4ed3
+        #uses: ros-tooling/setup-ros@a45da158f95f27fea0a57c88fa1da6275b0e4ed3
+        uses: mxgrey/setup-ros@explicit_libclang-rt-dev
         with:
           required-ros-distributions: ${{ matrix.ros_distribution }}
           use-ros2-testing: ${{ matrix.ros_distribution == 'rolling' }}

--- a/.github/workflows/reusable_build.yaml
+++ b/.github/workflows/reusable_build.yaml
@@ -55,7 +55,7 @@ jobs:
       - name: Setup ROS
         uses: ros-tooling/setup-ros@a45da158f95f27fea0a57c88fa1da6275b0e4ed3
         with:
-          required-ros-distribution: ${{ matrix.ros_distribution }}
+          required-ros-distributions: [${{ matrix.ros_distribution }}]
           use-ros2-testing: ${{ matrix.ros_distribution == 'rolling' }}
       - name: install_tools
         run: sudo apt update && sudo apt upgrade -y && sudo apt install -y ccache clang clang-tools lld wget python3-pip python3-colcon-coveragepy-result python3-colcon-lcov-result lcov ros-${{ matrix.ros_distribution }}-rmw-cyclonedds-cpp

--- a/.github/workflows/reusable_build.yaml
+++ b/.github/workflows/reusable_build.yaml
@@ -53,7 +53,7 @@ jobs:
             echo "fun:*Eigen*" >  ${{ github.workspace }}/blacklist.txt
           fi
       - name: Setup ROS
-        uses: ros-tooling/setup-ros@v0.7
+        uses: mxgrey/setup-ros@explicit_libclang-rt-dev
         with:
           required-ros-distribution: ${{ matrix.ros_distribution }}
           use-ros2-testing: ${{ matrix.ros_distribution == 'rolling' }}

--- a/.github/workflows/reusable_build.yaml
+++ b/.github/workflows/reusable_build.yaml
@@ -53,7 +53,7 @@ jobs:
             echo "fun:*Eigen*" >  ${{ github.workspace }}/blacklist.txt
           fi
       - name: Setup ROS
-        uses: mxgrey/setup-ros@explicit_libclang-rt-dev
+        uses: ros-tooling/setup-ros@a45da158f95f27fea0a57c88fa1da6275b0e4ed3
         with:
           required-ros-distribution: ${{ matrix.ros_distribution }}
           use-ros2-testing: ${{ matrix.ros_distribution == 'rolling' }}

--- a/.github/workflows/reusable_build.yaml
+++ b/.github/workflows/reusable_build.yaml
@@ -53,14 +53,11 @@ jobs:
             echo "fun:*Eigen*" >  ${{ github.workspace }}/blacklist.txt
           fi
       - name: Setup ROS
-        #uses: ros-tooling/setup-ros@a45da158f95f27fea0a57c88fa1da6275b0e4ed3
-        uses: mxgrey/setup-ros@explicit_libclang-rt-dev
+        uses: ros-tooling/setup-ros@a45da158f95f27fea0a57c88fa1da6275b0e4ed3
         with:
-          required-ros-distribution: ${{ matrix.ros_distribution }}
-          # required-ros-distributions: ${{ matrix.ros_distribution }}
           use-ros2-testing: ${{ matrix.ros_distribution == 'rolling' }}
       - name: install_tools
-        run: sudo apt update && sudo apt upgrade -y && sudo apt install -y ccache clang clang-tools lld wget python3-pip python3-colcon-coveragepy-result python3-colcon-lcov-result lcov ros-${{ matrix.ros_distribution }}-rmw-cyclonedds-cpp build-essential
+        run: sudo apt update && sudo apt upgrade -y && sudo apt install -y ccache clang clang-tools lld wget python3-pip python3-colcon-coveragepy-result python3-colcon-lcov-result lcov ros-${{ matrix.ros_distribution }}-rmw-cyclonedds-cpp
       - name: set mixins
         id: set_mixins
         run: |
@@ -75,10 +72,10 @@ jobs:
                 echo 'colcon_defaults={"build": {"mixin": ["ccache", "coverage-gcc", "lld"]}}' >> $GITHUB_OUTPUT
                 ;;
           esac
-      # - uses: actions/cache@v4
-      #   with:
-      #     path: ~/.cache/ccache
-      #     key: ccache
+      - uses: actions/cache@v4
+        with:
+          path: ~/.cache/ccache
+          key: ccache
       - name: set repos file
         run: |
           if [ -z ${{ inputs.repos-branch-override }} ]; then


### PR DESCRIPTION
We need the changes in https://github.com/ros-tooling/setup-ros/pull/889 for CI to work, but we aren't sure when setup-ros will have its next release. As a temporary measure to move our lyrical release along, we'll use the specific commit that we need and monitor setup-ros's next release.

Also note that I've removed the `required-ros-distribution` setting because the **actual** setting should be `required-ros-distributions` plural, but using that [creates new linking problems](https://github.com/ros-tooling/setup-ros/pull/889#issuecomment-4631404285). Since we were never actually relying on this setting (and using it is discouraged in the readme of `setup-ros`) I've removed it in this PR.