### PR TITLE
Explicitly install libstdc++-16-dev for Resolute

### DIFF
--- a/.github/workflows/reusable_build.yaml
+++ b/.github/workflows/reusable_build.yaml
@@ -58,6 +58,10 @@ jobs:
           use-ros2-testing: ${{ matrix.ros_distribution == 'rolling' }}
       - name: install_tools
         run: sudo apt update && sudo apt upgrade -y && sudo apt install -y ccache clang clang-tools lld wget python3-pip python3-colcon-coveragepy-result python3-colcon-lcov-result lcov ros-${{ matrix.ros_distribution }}-rmw-cyclonedds-cpp
+      # NOTE (aaronchongth): Installing explicitly due to https://github.com/open-rmf/rmf_ci_templates/issues/26
+      - name: install libstdc++-16-dev for resolute
+        if: matrix.ubuntu_distribution == 'resolute'
+        run: sudo apt install --install-recommends -y libstdc++-16-dev
       - name: set mixins
         id: set_mixins
         run: |


### PR DESCRIPTION
## Bug fix

### Fixed bug

Fixed compilation issues with `clang`, as experienced in https://github.com/open-rmf/rmf_ros2/pull/520

Tested with https://github.com/open-rmf/rmf_ros2/pull/529

Opened an issue https://github.com/open-rmf/rmf_ci_templates/issues/26, to be looked at down the road

### Fix applied

Install `libstdc++-16-dev` explicitly if the `resolute` is used.

Smoking gun was https://github.com/open-rmf/rmf_ros2/actions/runs/27138099037/job/80095623069?pr=520#step:11:3101.

When on Noble,

```bash
11:23:26 aaronchong@ubuntu24 ~ → apt rdepends --installed libstdc++-13-dev
libstdc++-13-dev
Reverse Depends:
  Depends: g++-13-x86-64-linux-gnu (= 13.3.0-6ubuntu2~24.04.1)
  Depends: clang-18
  Depends: libboost1.83-dev
  Depends: g++-13-x86-64-linux-gnu (= 13.2.0-23ubuntu4)
  Depends: clang-18
  Depends: libboost1.83-dev
```

When on Resolute (building locally on a docker),

```bash
root@0444b96a4dca:/rmf_ws# apt rdepends --installed libstdc++-15-dev
libstdc++-15-dev
Reverse Depends:
  Depends: g++-15-x86-64-linux-gnu (= 15.2.0-16ubuntu1)
  Depends: clang-21
  Depends: libboost1.90-dev
```

My guess is that one of these dependencies have not started installing `libstdc++-15-dev` as a dependency yet, hence the need to install it explicitly. Haven't dug very deeply as to why it happens yet, but I believe it should resolve itself once the upstream libraries stabilize on Resolute.

When on CI Resolute, build fails with version 15, installing 16 passes

### GenAI Use
We follow [OSRA's policy on GenAI tools](https://github.com/openrobotics/osrf-policies-and-procedures/blob/main/OSRF%20Policy%20on%20the%20Use%20of%20Generative%20Tools%20(%E2%80%9CGenerative%20AI%E2%80%9D)%20in%20Contributions.md)

- [ ] I used a GenAI tool in this PR.
- [x] I did not use GenAI

Generated-by:
